### PR TITLE
add support for specifying https protocol

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,7 +20,7 @@ Usage
 .. code-block:: python
 
     import pymagento
-    api = pymagento.Magento("hostname", "api_user", "api_key")
+    api = pymagento.Magento("hostname", "api_user", "api_key", scheme="https")
     category_id = api.category.create(1, {"name": "New Category"})
     category_info = api.category.info(category_id)
     arbitrary_product = api.product.list()[39]

--- a/pymagento/api.py
+++ b/pymagento/api.py
@@ -28,8 +28,8 @@ class Magento(object):
     class MagentoException(Exception):
         pass
 
-    def __init__(self, host, user, passwd):
-        self.proxy = xmlrpclib.ServerProxy("http://%s%s" % (host, MAGENTO_API_URI))
+    def __init__(self, host, user, passwd, scheme="http"):
+        self.proxy = xmlrpclib.ServerProxy("%s://%s%s" % (scheme,host, MAGENTO_API_URI))
         self.token = self.proxy.login(user, passwd)
 
     def close(self):


### PR DESCRIPTION
This patch provides optional support for specifying an alternate (e.g. "https") protocol / scheme for the xmlrpc URL.